### PR TITLE
Fix for MongoDB index creation

### DIFF
--- a/lib/mongoid_rateable/rateable.rb
+++ b/lib/mongoid_rateable/rateable.rb
@@ -10,10 +10,9 @@ module Mongoid
 
 			index(
 				[
-					["rating_marks.rater_id"],
-					["rating_marks.rater_class"]
-				],
-				unique: true
+					["rating_marks.rater_id", Mongo::ASCENDING],
+					["rating_marks.rater_class", Mongo::ASCENDING]
+				]
 			)
 
 			scope :unrated, where(:rating.exists => false)


### PR DESCRIPTION
Added required index type, removed unique index (not supported, http://stackoverflow.com/questions/4435637/mongodb-unique-key-in-embedded-document)
