### PR TITLE
Cascade callbacks to RatingMarks on save (fixes created_at = nil)

### DIFF
--- a/lib/mongoid_rateable/rateable.rb
+++ b/lib/mongoid_rateable/rateable.rb
@@ -23,7 +23,7 @@ module Mongoid
       field :rating_delta, type: Float, default: 0.0
       field :weighted_rate_count, type: Integer, default: 0
 
-      embeds_many :rating_marks, :as => :rateable
+      embeds_many :rating_marks, :as => :rateable, cascade_callbacks: true
 
       index({"rating_marks.rater_id" => 1, "rating_marks.rater_class" => 1})
 

--- a/spec/rateable_spec.rb
+++ b/spec/rateable_spec.rb
@@ -268,6 +268,10 @@ describe Post do
 		describe "#unweighted_rating" do
 			specify { @f_post.unweighted_rating.should eq -1.0 }
 		end
+
+		describe "rating timestamps" do
+			specify { @f_post.rating_marks.first.created_at.should_not be_nil }
+		end
 	end
 
 	describe "#rate_and_save" do


### PR DESCRIPTION
RatingMarks are embedded objects and were not receiving the save events, thus `created_at` was not being populated on save.
