### PR TITLE
Remove unnecessary console spam when initializing rateable

### DIFF
--- a/lib/mongoid_rateable/rateable.rb
+++ b/lib/mongoid_rateable/rateable.rb
@@ -9,7 +9,6 @@ module Mongoid
         def rateable options = {}
           class_eval do            
             self.send :include, Mongoid::Rateable
-            puts "options: #{options}"
             self.rate_config options
           end
         end


### PR DESCRIPTION
The log is unnecessary and my new hires often ask where it comes from.

```
bundle exec rspec
options: {:range=>1..5, :default_rater=>"owner"}
```
