### PR TITLE
mongoid 5

### DIFF
--- a/lib/mongoid_rateable/rateable.rb
+++ b/lib/mongoid_rateable/rateable.rb
@@ -26,8 +26,8 @@ module Mongoid
 
       index({"rating_marks.rater_id" => 1, "rating_marks.rater_class" => 1})
 
-      scope :unrated, where(:rating.exists => false)
-      scope :rated, where(:rating.exists => true)
+      scope :unrated, ->{ where(:rating.exists => false) }
+      scope :rated, ->{ where(:rating.exists => true) }
       scope :rated_by, ->(rater) { where("rating_marks.rater_id" => rater.id, "rating_marks.rater_class" => rater.class.to_s) }
       scope :with_rating, ->(range) { where(:rating.gte => range.begin, :rating.lte => range.end) }
       scope :highest_rated, ->(limit=10) { order_by([:rating, :desc]).limit(limit) }

--- a/lib/mongoid_rateable/rating.rb
+++ b/lib/mongoid_rateable/rating.rb
@@ -5,6 +5,6 @@ class RatingMark
   embedded_in :rateable, :polymorphic => true
   field :mark, :type => Integer
   field :rater_class, :type => String
-  field :rater_id, :type => Moped::BSON::ObjectId
+  field :rater_id, :type => BSON::ObjectId
   field :weight, :type => Integer, :default => 1
 end

--- a/lib/mongoid_rateable/version.rb
+++ b/lib/mongoid_rateable/version.rb
@@ -1,3 +1,3 @@
 module MongoidRateable
-  VERSION = '0.3.3'
+  VERSION = '0.3.4'
 end

--- a/mongoid_rateable.gemspec
+++ b/mongoid_rateable.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<mongoid>, ["~> 3.0"])
+      s.add_runtime_dependency(%q<mongoid>, ["~> 5.0"])
       s.add_development_dependency(%q<bundler>, ["~> 1"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.6"])
       s.add_development_dependency(%q<simplecov>, ["~> 0.4"])
@@ -60,7 +60,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<rspec>, ["~> 2.0"])
       s.add_development_dependency(%q<database_cleaner>, ["~> 0"])
     else
-      s.add_dependency(%q<mongoid>, ["~> 3.0"])
+      s.add_dependency(%q<mongoid>, ["~> 5.0"])
       s.add_dependency(%q<bundler>, ["~> 1"])
       s.add_dependency(%q<jeweler>, ["~> 1.6"])
       s.add_dependency(%q<simplecov>, ["~> 0.4"])
@@ -69,7 +69,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<database_cleaner>, ["~> 0"])
     end
   else
-    s.add_dependency(%q<mongoid>, ["~> 3.0"])
+    s.add_dependency(%q<mongoid>, ["~> 5.0"])
     s.add_dependency(%q<bundler>, ["~> 1"])
     s.add_dependency(%q<jeweler>, ["~> 1.6"])
     s.add_dependency(%q<simplecov>, ["~> 0.4"])

--- a/mongoid_rateable.gemspec
+++ b/mongoid_rateable.gemspec
@@ -53,6 +53,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<mongoid>, ["~> 5.0"])
+      s.add_runtime_dependency(%q<bson>, ["~> 4.1"])
       s.add_development_dependency(%q<bundler>, ["~> 1"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.6"])
       s.add_development_dependency(%q<simplecov>, ["~> 0.4"])
@@ -61,6 +62,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<database_cleaner>, ["~> 0"])
     else
       s.add_dependency(%q<mongoid>, ["~> 5.0"])
+      s.add_dependency(%q<bson>, ["~> 4.1"])
       s.add_dependency(%q<bundler>, ["~> 1"])
       s.add_dependency(%q<jeweler>, ["~> 1.6"])
       s.add_dependency(%q<simplecov>, ["~> 0.4"])
@@ -70,6 +72,7 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<mongoid>, ["~> 5.0"])
+    s.add_dependency(%q<bson>, ["~> 4.1"])
     s.add_dependency(%q<bundler>, ["~> 1"])
     s.add_dependency(%q<jeweler>, ["~> 1.6"])
     s.add_dependency(%q<simplecov>, ["~> 0.4"])


### PR DESCRIPTION
As mongoid 5 does not use Moped any more, it is not possible to use Moped::BSON::ObjectId, but it is possible to use BSON::ObjectId.
Also the scopes have to be inside a proc now (mongo gem 2.2.5).
